### PR TITLE
Disable GPG signing by default

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     byebug (11.1.3)
-    console (1.8.2)
+    console (1.9.0)
     diff-lcs (1.4.4)
     git (1.7.0)
       rchardet (~> 1.8)
@@ -31,7 +31,7 @@ GEM
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
     thor (0.20.3)
-    zeitwerk (2.3.1)
+    zeitwerk (2.4.0)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ By default it will look for a file called `.bumper_config.json"` but you can spe
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/lib/dependency_bumper/updater.rb
+++ b/lib/dependency_bumper/updater.rb
@@ -46,6 +46,8 @@ module DependencyBumper
 
       git_repo.add(all: true)
       git_repo.commit(output)
+    rescue Git::GitExecuteError => error
+      Console.logger.error(error)
     end
 
     def git_config_username_email(repo)
@@ -56,6 +58,7 @@ module DependencyBumper
       else
         Console.logger.info('User name and email is set, read to commit')
       end
+      repo.config('commit.gpgsign', config.dig('git', 'commit', 'gpgsign').to_s)
     end
 
     def report_result

--- a/spec/dependency_bumper_spec.rb
+++ b/spec/dependency_bumper_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe DependencyBumper do
   let(:default_config) do
-    { 'skip' => {}, 'outdated_level' => 'strict', 'update' => { 'default' => 'minor', 'major' => {}, 'minor' => {}, 'patch' => {} } }
+    DependencyBumper::Cli::DEFAULT_CONFIGURATION.dup
   end
 
   let(:number_of_cores) { Etc.nprocessors }
@@ -93,8 +93,7 @@ RSpec.describe DependencyBumper do
       Dir.mktmpdir do |dir|
         g = Git.init(dir)
 
-        file = File.new("#{dir}/temp", 'w')
-        file.write('hello world')
+        IO.write("#{dir}/temp", 'hello world')
 
         dp = DependencyBumper::Updater.new(default_config, true)
         allow(dp).to receive(:report_result).and_return(updated_gems)


### PR DESCRIPTION
I have gpg signing enabled by default. So when I run the tests, I am prompted to enter the pass phrase to unlock my GPG private key so that I can sign the commit. I think that specifying a way to configure gpg signing makes it possible to run the unit tests without needing to enter a pass phrase to finish running the unit tests.

Before:

![Peek 2020-08-01 13-19](https://user-images.githubusercontent.com/80475/89108881-9e0a1600-d3f9-11ea-9da9-ee6c46b4e6ed.gif)

After:

![Peek 2020-08-01 13-21](https://user-images.githubusercontent.com/80475/89108911-e0335780-d3f9-11ea-87e1-ca9f6e07959d.gif)
